### PR TITLE
Update gen3-client links to point to upstream

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,7 +22,3 @@ For the ACED data commons, we have created a data dictionary based on the FHIR d
 > [more](https://gen3.org/resources/operator/#6-programs-and-projects)
 
 For the following examples, we will use the `aced` program with a project called `myproject`, please use the `g3t projects ls` command to verify what programs you have access to.
-
-## Next steps
-
-- [Install gen3-client](requirements/gen3-client.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,6 @@ This is the documentation for the [ACED-IDP Data Commons](https://aced-idp.org),
 
 ## Getting Started
 
-Please see the [Getting Started](./getting-started.md) page for instructions on how to installing the required tools needed to create a project, add authorized users, and upload and download files..
+Please see the [Getting Started](./getting-started.md) page for instructions on how to installing the required tools needed to create a project, add authorized users, and upload and download files.
 
-<a href="./getting-started">![Main landing page for ACED IDP](./images/main-page.png)</a>
+<a href="https://aced-idp.org">![Main landing page for ACED IDP](./images/main-page.png)</a>

--- a/docs/requirements/gen3-client.md
+++ b/docs/requirements/gen3-client.md
@@ -22,10 +22,10 @@ A binary executable of the latest version of the gen3-client should be downloade
 ### Installation Instructions
 
 ??? "macOS Installation Instructions"
-    1. Download the latest Linux version of the gen3-client.
-    2. Unzip the archive.
-    3. Add the unzipped executable to a directory, for example: `~/.gen3/gen3-client`
-    4. Open a terminal window.
+    1. Download the latest macOS version ([dataclient_osx.pkg][macos]).
+    2. Follow the instructions in the installer
+    3. Open a terminal window.
+    4. Move the executable to the default directory: `mv /Applications/gen3-client ~/.gen3/gen3-client`
     5. Add the directory containing the executable to your Path environment variable by entering this command in the terminal: `echo 'export PATH=$PATH:~/.gen3' >> ~/.bash_profile`
     6. Run `source ~/.bash_profile` or restart your terminal.
     7. Now you can execute the program by opening a terminal window and entering the command `gen3-client`

--- a/docs/requirements/gen3-client.md
+++ b/docs/requirements/gen3-client.md
@@ -4,99 +4,52 @@ title: gen3-client
 
 {% include '/note.md' %}
 
-!!! warning
-    It is important to use the `gen3-client` from the [ACED Github Release Page](https://github.com/ACED-IDP/cdis-data-client/releases), as it includes several updates from the "upstream" version including support for the `--bucket` flag as well as multipart uploads.
-
-!!! note
-    This page is adapted from the ['Download and Upload Files Using the Gen3-client'](https://gen3.org/resources/user/gen3-client/) page from the main [Gen3 website](https://gen3.org/). This site has a wealth of information that supplements the ACED-IDP project including in-depth examples and usages of the gen3-client.
-
 ## Downloading gen3-client
 
 A binary executable of the latest version of the gen3-client should be downloaded from the following Table or from the [Release page on Github](https://github.com/ACED-IDP/cdis-data-client/releases). Choose the file that matches your operating system (Windows, Linux, or macOS).
 
-No installation is necessary. Simply download the correct version for your operating system and unzip the archive. The program is then executed from the command-line by running the command gen3-client <options>. For more detailed instructions, see the section below for your operating system.
+| Operating System | Gen3 Client                      | Checksum                   |
+|------------------|----------------------------------|----------------------------|
+| macOS            | [dataclient_osx.pkg][macos]      | [checksums.txt][checksums] |
+| Linux            | [dataclient_linux.zip][linux]   | [checksums.txt][checksums] |
+| Windows          | [dataclient_win64.zip][windows] | [checksums.txt][checksums] |
 
-| Operating System      | Gen3 Client                              | Checksum                   |
-| --------------------- | ---------------------------------------- | -------------------------- |
-| macOS (Apple Silicon) | [gen3-client-macos.zip][macos-arm]       | [checksums.txt][checksums] |
-| macOS (Intel)         | [gen3-client-macos-intel.zip][macos]     | [checksums.txt][checksums] |
-| Linux (amd64)         | [gen3-client-linux-amd64.zip][linux]     | [checksums.txt][checksums] |
-| Windows (amd64)       | [gen3-client-windows-amd64.zip][windows] | [checksums.txt][checksums] |
+[macos]: https://github.com/uc-cdis/cdis-data-client/releases/download/1.2.0/dataclient_osx.pkg
+[linux]: https://github.com/uc-cdis/cdis-data-client/releases/download/1.2.0/dataclient_linux.zip
+[windows]: https://github.com/uc-cdis/cdis-data-client/releases/download/1.2.0/dataclient_win64.zip
+[checksums]: https://github.com/ACED-IDP/cdis-data-client/releases/download/1.2.0/checksums.txt
 
-[macos-arm]: https://github.com/ACED-IDP/cdis-data-client/releases/latest/download/gen3-client-macos.zip
-[macos]: https://github.com/ACED-IDP/cdis-data-client/releases/latest/download/gen3-client-macos-intel.zip
-[linux]: https://github.com/ACED-IDP/cdis-data-client/releases/latest/download/gen3-client-linux-amd64.zip
-[windows]: https://github.com/ACED-IDP/cdis-data-client/releases/latest/download/gen3-client-windows-amd64.zip
-[checksums]: https://github.com/ACED-IDP/cdis-data-client/releases/latest/download/checksums.txt
+### Installation Instructions
 
-!!! warning
-    Do not try to run the program by double-clicking on it. Instead, execute the program from within the shell / terminal / command prompt. The program does not provide a graphical user interface (GUI) at this time; so, commands are sent by typing them into the terminal.
+??? "macOS Installation Instructions"
+    1. Download the latest Linux version of the gen3-client.
+    2. Unzip the archive.
+    3. Add the unzipped executable to a directory, for example: `~/.gen3/gen3-client`
+    4. Open a terminal window.
+    5. Add the directory containing the executable to your Path environment variable by entering this command in the terminal: `echo 'export PATH=$PATH:~/.gen3' >> ~/.bash_profile`
+    6. Run `source ~/.bash_profile` or restart your terminal.
+    7. Now you can execute the program by opening a terminal window and entering the command `gen3-client`
 
-### Checksum Verification
+??? "Linux Installation Instructions"
+    1. Download the latest Linux version of the gen3-client.
+    2. Unzip the archive.
+    3. Add the unzipped executable to a directory, for example: `~/.gen3/gen3-client`
+    4. Open a terminal window.
+    5. Add the directory containing the executable to your Path environment variable by entering this command in the terminal: `echo 'export PATH=$PATH:~/.gen3' >> ~/.bash_profile`
+    6. Run `source ~/.bash_profile` or restart your terminal.
+    7. Now you can execute the program by opening a terminal window and entering the command `gen3-client`
 
-In order to verify that the downloaded file can be trusted checksums are provided in [`checksums.txt`][checksums]. See below for examples of how to use this file.
-
-<details>
-<summary>Successful Verification</summary>
-
-To verify the integrity of the binaries on macOS run the following command in the same directory as the downloaded file:
-
-```sh
-$ shasum -c checksums.txt --ignore-missing
-gen3-client-macos.zip: OK
-```
-
-If the `shasum` command outputs `OK` than the verification was successful and the executable can be trusted.
-
-</details>
-
-<details>
-<summary>Unsuccessful Verification</summary>
-
-Alternatively if the command outputs `FAILED` than the checksum did not match and the binary should not be run.
-
-```sh
-$ shasum -c checksums.txt --ignore-missing
-gen3-client-macos.zip: FAILED
-shasum: WARNING: 1 computed checksum did NOT match
-shasum: checksums.txt: no file was verified
-```
-
-In such a case please reach out to the contributors for assistance.
-
-</details>
-
-## MacOS / Linux Installation Instructions
-
-1. Download the latest macOS (Apple Silicon or Intel) or Linux version of the gen3-client.
-2. Unzip the archive.
-3. Add the unzipped executable to a directory, for example: `~/.gen3/gen3-client`
-4. Open a terminal window.
-5. Add the directory containing the executable to your Path environment variable by entering this command in the terminal: `echo 'export PATH=$PATH:~/.gen3' >> ~/.bash_profile`
-6. Run `source ~/.bash_profile` or restart your terminal.
-7. Now you can execute the program by opening a terminal window and entering the command `gen3-client`
-
-!!! note
-    If your macOS does not allow access, you need to manually allow it under System Preferences > Security & Privacy > General (click the lock icon to unlock, enter administrator name and password).
-
-## Windows Installation Instructions
-
-1. Download the Windows  version of the gen3-client.
-2. Unzip the archive.
-3. Add the unzipped executable to a directory, for example: `C:\Program Files\gen3-client\gen3-client.exe`
-4. Open the Start Menu and type "edit environment variables".
-5. Open the option "Edit the system environment variables".
-6. In the "System Properties" window that opens up, on the "Advanced" tab, click on the "Environment Variables" button.
-7. In the box labeled "System Variables", find the "Path" variable and click "Edit".
-8. In the window that pops up, click "New".
-9. Type in the full directory path of the executable file, for example: `C:\Program Files\gen3-client`
-10. Click "Ok" on all the open windows and restart the command prompt if it is already open by entering cmd into the start menu and hitting enter.
-
-## View the Help Menu
-
-To check that your copy of the client is working and confirm the version, the tool can be run on the command-line in your terminal or command prompt by entering `gen3-client`. Typing this alone or `gen3-client help` will display the help menu. For help on a particular command, enter: `gen3-client <command> help`.
-
-Note that you must provide the full path of the tool in order for the commands to run, for example, `./gen3-client` while working from the directory containing the client. Alternatively, you can add the location of the gen3-client executable to your shell’s PATH environment variable.
+??? "Windows Installation Instructions"
+    1. Download the Windows  version of the gen3-client.
+    2. Unzip the archive.
+    3. Add the unzipped executable to a directory, for example: `C:\Program Files\gen3-client\gen3-client.exe`
+    4. Open the Start Menu and type "edit environment variables".
+    5. Open the option "Edit the system environment variables".
+    6. In the "System Properties" window that opens up, on the "Advanced" tab, click on the "Environment Variables" button.
+    7. In the box labeled "System Variables", find the "Path" variable and click "Edit".
+    8. In the window that pops up, click "New".
+    9. Type in the full directory path of the executable file, for example: `C:\Program Files\gen3-client`
+    10. Click "Ok" on all the open windows and restart the command prompt if it is already open by entering cmd into the start menu and hitting enter.
 
 ## Configure a Profile with Credentials
 
@@ -108,30 +61,17 @@ Download the access key from the portal and save it in the standard location `~/
 
 ![Gen3 Credentials](credentials.png)
 
-From the command-line, run the gen3-client configure command with the `--cred`, `--apiendpoint`, and `--profile` flags, for example:
+From the command-line, run the gen3-client configure command:
 
 ```sh
 gen3-client configure --profile=<profile_name> --cred=<credentials.json> --apiendpoint=https://aced-idp.org
 
-# Mac/Linux:
+# Mac/Linux Example:
 gen3-client configure --profile=demo --cred=~/Downloads/credentials.json --apiendpoint=https://aced-idp.org
 
-# Windows:
+# Windows Example:
 gen3-client configure --profile=demo --cred=C:\Users\demo\Downloads\credentials.json --apiendpoint=https://aced-idp.org
 ```
-
-When successfully executed, this will create a configuration file, which contains all the API keys and URLs associated with each commons profile configured, located in the user folder:
-
-```sh
-# Mac/Linux:
-/Users/demo/.gen3/gen3_client_config.ini
-
-# Windows:
-C:\Users\demo\.gen3\gen3_client_config.ini
-```
-
-!!! warning
-    These keys must be treated like important passwords; never share the contents of the credentials.json and gen3-client gen3_client_config.ini or config file!
 
 To confirm you successfully configured a profile with the correct authorization privileges, you can run the `gen3-client auth` command, which should list your access privileges for each project in the commons you have access to:
 
@@ -142,7 +82,3 @@ gen3-client auth --profile=aced
 # You have access to the following resource(s) at https://aced-idp.org:
 # 2023/12/05 15:07:12 /programs/aced/projects/myproject...
 ```
-
-## Next steps
-
-- [Install the gen3 tracker](gen3-tracker.md)

--- a/docs/requirements/gen3-client.md
+++ b/docs/requirements/gen3-client.md
@@ -6,7 +6,7 @@ title: gen3-client
 
 ## Downloading gen3-client
 
-A binary executable of the latest version of the gen3-client should be downloaded from the following Table or from the [Release page on Github](https://github.com/ACED-IDP/cdis-data-client/releases). Choose the file that matches your operating system (Windows, Linux, or macOS).
+A binary executable of the latest version of the gen3-client should be downloaded from the following Table or from the [Release page on Github](https://github.com/uc-cdis/cdis-data-client/releases). Choose the file that matches your operating system (Windows, Linux, or macOS).
 
 | Operating System | Gen3 Client                      | Checksum                   |
 |------------------|----------------------------------|----------------------------|

--- a/docs/requirements/gen3-tracker.md
+++ b/docs/requirements/gen3-tracker.md
@@ -12,7 +12,7 @@ The `gen3-tracker (g3t)` tool requires a working [Python 3](https://www.python.o
 # Optionally create a virtual environment
 python3 -m venv venv; source venv/bin/activate
 
-pip install gen3_util
+pip install gen3-tracker
 ```
 
 You can verify the installation was successful by then running the `g3t` command with the expected output being the latest version:
@@ -28,14 +28,14 @@ version: 0.0.14rc4
 This version should match the latest version on the [PyPi page](https://pypi.org/project/gen3-util/). If it is out of date, simply run the following to upgrade your local version:
 
 ```sh
-pip install -U gen3_util
+pip install -U gen3-tracker
 ```
 
 ### Configuration
 
 g3t uses the [gen3-client](https://gen3.org/resources/user/gen3-client/#2-configure-a-profile-with-credentials) configuration flow.
 
-After configuration, you can either specify the `--profile` option or set the `GEN3_UTIL_PROFILE=profile-name` environmental variable.
+After configuration, you can either specify the `--profile` option or set the `G3T_PROFILE=profile-name` environmental variable.
 
 
 ### Testing the configuration
@@ -67,7 +67,3 @@ Alternatively, you can set the environmental variables using the `EXPORT` functi
 ```sh
 export G3T_PROJECT_ID=aced-myproject
 ```
-
-## Next steps
-
-- [Create a Project](../workflows/creating-project.md)

--- a/docs/workflows/add-users.md
+++ b/docs/workflows/add-users.md
@@ -21,10 +21,3 @@ In order to implement these requests, **an authorized user will need to sign** t
 ```sh
 g3t utilities users add --username someone@example.com --project_id aced-myproject
 ```
-
-## Next steps
-
-At this point you should now be ready to dive further into the ACED-IDP ecosystem with the following guides:
-
-- [Uploading data to a project](./upload.md)
-- [Downloading data from a project](./portal-download.md)

--- a/docs/workflows/clone.md
+++ b/docs/workflows/clone.md
@@ -21,7 +21,3 @@ Options:
                                 [default: meta]
 
 ```
-
-## Next steps
-
-- [Downloading data from a project](./portal-download.md)

--- a/docs/workflows/creating-project.md
+++ b/docs/workflows/creating-project.md
@@ -47,11 +47,7 @@ While you can work with an initialized repository locally, **an authorized user 
 
 ```
 
-
-
 ## Next steps
-
-At this point you should now be ready to dive further into the ACED-IDP ecosystem with the following guides:
 
 - [Adding users to a project](./add-users.md)
 - [Uploading data to a project](./upload.md)

--- a/docs/workflows/upload.md
+++ b/docs/workflows/upload.md
@@ -57,7 +57,5 @@ Note that we use `xargs` `-P 0` argument to run commands in parallel, greatly re
 
 ## Next steps
 
-
 * See the  <a href="/workflows/status/">status command</a> for more information on how to verify the manifest.
 * See the  <a href="/workflows/metadata/">metadata workflow section</a> for more information on how to create and upload metadata.
-

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,7 @@ theme:
   features:
     - navigation.indexes 
     - navigation.footer
+    - content.code.copy
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
- Update gen3_util to gen3-tracker (g3t)
- gen3-client release page: https://github.com/uc-cdis/cdis-data-client/releases/latest